### PR TITLE
remove trustline requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "kin.js",
-  "version": "1.0.3",
+  "name": "@kinecosystem/kin.js",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinecosystem/kin.js",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A typescript/javascript implementation of the Kin sdk",
   "main": "scripts/bin/index.js",
   "types": "scripts/bin/index.d.ts",

--- a/scripts/src/stellar.ts
+++ b/scripts/src/stellar.ts
@@ -56,6 +56,7 @@ export function isKinAccount(account: StellarSdk.AccountResponse, asset: Asset):
 }
 
 export function getKinBalance(account: StellarSdk.AccountResponse, asset: Asset): KinBalance | undefined {
+	// return the balance of the given asset or undefined when asset isn't trusted
 	return account && account.balances ?
 		account.balances.find(balance => isKinBalance(balance, asset)) as KinBalance
 		: undefined;
@@ -177,14 +178,14 @@ export class Operations {
 	}
 
 	public async send(operation: xdr.Operation<Operation.Operation>, memoText?: string): Promise<TransactionRecord> {
-		const account = await this.loadAccount(this.keys.publicKey());
+		const account = await this.loadAccount(this.keys.publicKey());  // loads the sequence number
 		return await this._send(account, operation, memoText);
 	}
 
-	public async establishTrustLine(address: string, account?: StellarSdk.AccountResponse): Promise<KinBalance> {
+	public async establishTrustLine(): Promise<KinBalance> {
 		const op = StellarSdk.Operation.changeTrust({ asset: this.asset });
 		await this.send(op);
-		return this.checkKinBalance(address);
+		return this.checkKinBalance(this.keys.publicKey());
 	}
 
 	@retry({ errorMessagePrefix: "failed to load account" })


### PR DESCRIPTION
the latest blockchain build allows trustlines to be established upon account creation. The client can skip this stage now unless it is explicitly requested